### PR TITLE
bugfix: fix wrong tips for autoUpdateZ

### DIFF
--- a/packages/fie-module/lib/get.js
+++ b/packages/fie-module/lib/get.js
@@ -83,7 +83,7 @@ function* get(name) {
             }
 
             if (autoZVersion) {
-              log.info('autoUpdateZ', { localVersion: localPkg.version, autoZVersion });
+              log.info(`autoUpdateZ localVersion: ${localPkg.version}, autoZVersion: ${autoZVersion}` );
               const comPkg = yield npm.latest(name, {
                 version: autoZVersion
               });


### PR DESCRIPTION
修正了autoUpdateZ的显示错误，改为autoUpdateZ localversion:x.y.z, autoZVersion: x.y.z